### PR TITLE
Add configurable DeathLink trigger mode

### DIFF
--- a/CommonData/ArchipelagoEventManager.cs
+++ b/CommonData/ArchipelagoEventManager.cs
@@ -39,7 +39,7 @@ namespace YargArchipelagoPlugin
             if (!parent.IsSessionConnected || parent.seedConfig is null)
                 return;
 
-            if (parent.seedConfig.DeathLinkMode > DeathLinkType.disabled)
+            if (parent.seedConfig.DeathLinkMode > DeathLinkType.disabled && parent.seedConfig.DeathLinkTrigger != DeathLinkTriggerType.failed_requirements_only)
                 parent.DeathLinkService?.SendDeathLink(new DeathLink(parent.GetSession().Players.ActivePlayer.Name, $"Failed Song {gameManager.Song.Name} by {gameManager.Song.Artist}"));
         }
 
@@ -85,7 +85,7 @@ namespace YargArchipelagoPlugin
 
             ExtraAPFunctionalityHelper.SendScoreAsEnergy(parent, gameManager.BandScore, HasLocationsTocheck);
 
-            if (DoDeathlink && (parent.seedConfig?.DeathLinkMode ?? DeathLinkType.disabled) > DeathLinkType.disabled)
+            if (DoDeathlink && (parent.seedConfig?.DeathLinkMode ?? DeathLinkType.disabled) > DeathLinkType.disabled && parent.seedConfig.DeathLinkTrigger != DeathLinkTriggerType.song_fail_only)
                 parent.DeathLinkService?.SendDeathLink(
                     new DeathLink(parent.GetSession().Players.ActivePlayer.Name,
                     $"Failed to meet the requirements playing {gameManager.Song.Name} by {gameManager.Song.Artist}"));
@@ -106,7 +106,7 @@ namespace YargArchipelagoPlugin
             if (MetStandard && MetExtra)
                 parent.GetSession().Locations.CompleteLocationChecks(parent.SlotData.GoalData.MainLocationID);
 
-            if ((deathLinkExtra || deathLinkStandard) && (parent.seedConfig?.DeathLinkMode ?? DeathLinkType.disabled) > DeathLinkType.disabled)
+            if ((deathLinkExtra || deathLinkStandard) && (parent.seedConfig?.DeathLinkMode ?? DeathLinkType.disabled) > DeathLinkType.disabled && parent.seedConfig.DeathLinkTrigger != DeathLinkTriggerType.song_fail_only)
                 parent.DeathLinkService?.SendDeathLink(
                     new DeathLink(parent.GetSession().Players.ActivePlayer.Name,
                     $"Failed to meet the requirements playing {manager.Song.Name} by {manager.Song.Artist}"));

--- a/CommonData/ArchipelagoService.cs
+++ b/CommonData/ArchipelagoService.cs
@@ -289,6 +289,11 @@ namespace YargArchipelagoPlugin
         public DeathLinkType DeathLinkMode = DeathLinkType.disabled;
 
         /// <summary>
+        /// This value tracks when deathlink should trigger. It can be changed in game independently of the yaml.
+        /// </summary>
+        public DeathLinkTriggerType DeathLinkTrigger = DeathLinkTriggerType.both;
+
+        /// <summary>
         /// This value tracks the current energylink mode. It can be changed in game independently of the yaml.
         /// </summary>
         public EnergyLinkType EnergyLinkMode = EnergyLinkType.disabled;

--- a/CommonData/CommonData.cs
+++ b/CommonData/CommonData.cs
@@ -208,6 +208,15 @@ namespace YargArchipelagoCommon
             [Description("Instant Fail")]
             instant_fail = 2,
         }
+        public enum DeathLinkTriggerType
+        {
+            [Description("Both")]
+            both = 0,
+            [Description("Song Fail Only")]
+            song_fail_only = 1,
+            [Description("Failed Reqs Only")]
+            failed_requirements_only = 2,
+        }
         public enum EnergyLinkType
         {
             [Description("Disabled")]

--- a/CommonData/Forms.cs
+++ b/CommonData/Forms.cs
@@ -265,6 +265,18 @@ namespace YargArchipelagoPlugin
                 GUILayout.EndVertical();
 
                 GUILayout.BeginVertical(GUILayout.Width(188));
+                GUILayout.Label($"DL Trigger:");
+                GUILayout.Label($" ");
+                string deathLinkTriggerText = isConnected ? connectionContainer.seedConfig.DeathLinkTrigger.GetDescription() : "N/A";
+                if (GUILayout.Button(deathLinkTriggerText, GUILayout.Height(20)))
+                    if (isConnected)
+                    {
+                        connectionContainer.seedConfig.DeathLinkTrigger = YargAPUtils.CycleEnum(connectionContainer.seedConfig.DeathLinkTrigger);
+                        connectionContainer.seedConfig.Save();
+                    }
+                GUILayout.EndVertical();
+
+                GUILayout.BeginVertical(GUILayout.Width(188));
                 string energyLinkYaml = isConnected ? connectionContainer.SlotData.EnergyLink.GetDescription() : "N/A";
                 GUILayout.Label($"Energy Link:");
                 GUILayout.Label($"YAML: {energyLinkYaml}");


### PR DESCRIPTION
Allow users to choose when DeathLink triggers: on song failure only, on failed score requirements only, or both (default, preserving current behavior). Adds a UI toggle in the settings menu.